### PR TITLE
docs: refresh index pages and mission blurb

### DIFF
--- a/DSCOVR/index.qmd
+++ b/DSCOVR/index.qmd
@@ -23,3 +23,5 @@ author: "Atmospheric Science Data Center (ASDC)"
 #### - [Compare TEMPO and DSCOVR aerosol data (spatially)](../DSCOVR/how_to_compare_spatially_TEMPO_with_DSCOVR_uvai.ipynb)
 
 #### - [Compare TEMPO, DSCOVR, and AERONET aerosol data](../DSCOVR/how_to_compare_TEMPO_with_DSCOVR_and_AERONET_uvai.ipynb)
+
+#### - [Visualize UV Aerosol Index from EPIC](../DSCOVR/how_to_visualize_DSCOVR-UVAI.ipynb)

--- a/PREFIRE/index.qmd
+++ b/PREFIRE/index.qmd
@@ -13,3 +13,5 @@ author: "Atmospheric Science Data Center (ASDC)"
 #### - [Plot spatial maps of Level-2 cloud data for a polar region](../PREFIRE/plot_PREFIRE_L2_CLD_with_earthaccess_and_Harmony.ipynb)
 
 #### - [Plot time series of data for points of interest](../PREFIRE/PREFIRE_timeseries_with_earthaccess_and_Harmony.ipynb)
+
+#### - [Generate and read a virtual datacube for PREFIRE](../PREFIRE/how_to_generate_and_read_virtual_datacube-for-PREFIRE.ipynb)

--- a/index.qmd
+++ b/index.qmd
@@ -1,31 +1,22 @@
 ---
-title: "ASDC Data and User Services Tutorials and Resources"
-subtitle: "With mission-specific guidance"
+title: "ASDC Data and User Services"
+subtitle: "Tutorials and resources with mission-specific guidance"
 date: last-modified
 author: "Atmospheric Science Data Center (ASDC)"
 ---
 
 ## Welcome {#welcome}
 
-**Welcome to the Data and User Services repository for the
-NASA Atmospheric Science Data Center ([ASDC](https://asdc.larc.nasa.gov/))!**
+How-to guides (goal-oriented tasks), tutorials (learning-oriented walkthroughs),
+and scripts for working with data from missions
+archived and distributed by NASA's
+[Atmospheric Science Data Center (ASDC)](https://www.earthdata.nasa.gov/centers/asdc-daac).
 
-This GitHub page serves as a comprehensive resource for end users
-seeking guidance and instructions on
-working with data from select missions that are archived and distributed by
-the ASDC Distributed Active Archive Center (DAAC).
-Its aim is to enhance the knowledge and proficiency of data users,
-enabling more effective usage of the valuable resources made available by ASDC.
-Through this transfer of expertise from ASDC to users, we hope to
-foster a collaborative environment that drives innovation and progress in space-related endeavors.
+Browse the sidebar for mission-specific guidance covering
+CALIPSO, CERES, DSCOVR, MAIA, MISR, MOPITT, POWER, PREFIRE,
+SAGE III-ISS, STAQS, TEMPO, and TOLNet.
+Examples cover working with NASA Earthdata on your local machine as well as
+in the cloud.
 
-**In the left sidebar...**
-
-You will find how-to guides (for goal-oriented tasks), tutorials (for learning), and scripts 
-for select missions and a variety of use cases. 
-Examples are provided for working with NASA Earthdata both on your local machine as well as in the cloud.
-The cloud-based guides exemplify the advantages of working with NASA Earthdata in the cloud and
-aim to provide a starting point for exploring what your own workflows could look like in the cloud.
-
-
-*This site is under active, open development. Stay tuned for more and ever-evolving content!* 
+*This site is under active, open development. Stay tuned for more and
+ever-evolving content!*

--- a/mission-index-blurb.qmd
+++ b/mission-index-blurb.qmd
@@ -1,8 +1,5 @@
 
-The following guides show example workflows
-with this mission's data for a variety of use cases.
-These guides aim to provide a starting point for exploring what your workflows
-could look like.
-Please contact us via the [Earthdata Forum](http://forum.earthdata.nasa.gov/) or create an
-[_issue_ in the ASDC Data & User Services GitHub repository](https://github.com/nasa/ASDC_Data_and_User_Services/issues)
-to let us know any questions or if you encounter any problems.
+Example workflows for a variety of use cases with this mission's data.
+Have questions or run into problems? Reach out via the
+[Earthdata Forum](https://forum.earthdata.nasa.gov/) or open an
+[issue](https://github.com/nasa/ASDC_Data_and_User_Services/issues).


### PR DESCRIPTION
## Refresh site landing pages

Tighten content text and fix gaps across the Quarto site's index pages so visitors get a clearer, more complete picture at each landing point.

### Changes

- **`index.qmd`** — rewrite: concise intro, updated ASDC link, explicit mission list, content-type taxonomy hint
- **`mission-index-blurb.qmd`** — trim filler language; fix `http` → `https` on Earthdata Forum link
- **`DSCOVR/index.qmd`** — add missing DSCOVR-UVAI notebook link
- **`PREFIRE/index.qmd`** — add missing virtual datacube notebook link
